### PR TITLE
Sets an environment variable with artifact image details

### DIFF
--- a/src/main/java/cd/go/artifact/docker/registry/ConsoleLogger.java
+++ b/src/main/java/cd/go/artifact/docker/registry/ConsoleLogger.java
@@ -22,7 +22,7 @@ import com.thoughtworks.go.plugin.api.request.DefaultGoApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoApiResponse;
 
-import static cd.go.artifact.docker.registry.Constants.API_VERSION;
+import static cd.go.artifact.docker.registry.Constants.CONSOLE_LOG_PROCESSOR_API_VERSION;
 import static cd.go.artifact.docker.registry.Constants.PLUGIN_IDENTIFIER;
 import static cd.go.artifact.docker.registry.DockerRegistryArtifactPlugin.LOG;
 
@@ -43,7 +43,7 @@ public class ConsoleLogger {
     }
 
     private void sendLog(ConsoleLogMessage consoleLogMessage) {
-        DefaultGoApiRequest request = new DefaultGoApiRequest(Constants.SEND_CONSOLE_LOG, API_VERSION, PLUGIN_IDENTIFIER);
+        DefaultGoApiRequest request = new DefaultGoApiRequest(Constants.SEND_CONSOLE_LOG, CONSOLE_LOG_PROCESSOR_API_VERSION, PLUGIN_IDENTIFIER);
         request.setRequestBody(consoleLogMessage.toJSON());
 
         GoApiResponse response = accessor.submit(request);

--- a/src/main/java/cd/go/artifact/docker/registry/Constants.java
+++ b/src/main/java/cd/go/artifact/docker/registry/Constants.java
@@ -25,7 +25,7 @@ public interface Constants {
     String EXTENSION_TYPE = "artifact";
 
     // The extension point API version that this plugin understands
-    String API_VERSION = "1.0";
+    String API_VERSION = "2.0";
 
     // the identifier of this plugin
     GoPluginIdentifier PLUGIN_IDENTIFIER = new GoPluginIdentifier(EXTENSION_TYPE, Collections.singletonList(API_VERSION));

--- a/src/main/java/cd/go/artifact/docker/registry/Constants.java
+++ b/src/main/java/cd/go/artifact/docker/registry/Constants.java
@@ -25,10 +25,11 @@ public interface Constants {
     String EXTENSION_TYPE = "artifact";
 
     // The extension point API version that this plugin understands
-    String API_VERSION = "2.0";
+    String EXTENSION_API_VERSION = "2.0";
+    String CONSOLE_LOG_PROCESSOR_API_VERSION = "1.0";
 
     // the identifier of this plugin
-    GoPluginIdentifier PLUGIN_IDENTIFIER = new GoPluginIdentifier(EXTENSION_TYPE, Collections.singletonList(API_VERSION));
+    GoPluginIdentifier PLUGIN_IDENTIFIER = new GoPluginIdentifier(EXTENSION_TYPE, Collections.singletonList(EXTENSION_API_VERSION));
 
     // requests that the plugin makes to the server
     String REQUEST_SERVER_PREFIX = "go.processor";

--- a/src/main/java/cd/go/artifact/docker/registry/DockerRegistryArtifactPlugin.java
+++ b/src/main/java/cd/go/artifact/docker/registry/DockerRegistryArtifactPlugin.java
@@ -74,7 +74,7 @@ public class DockerRegistryArtifactPlugin implements GoPlugin {
                 case REQUEST_FETCH_ARTIFACT_VIEW:
                     return new GetFetchArtifactViewExecutor().execute();
                 case REQUEST_FETCH_ARTIFACT_VALIDATE:
-                    return new ValidateFetchArtifactConfigExecutor().execute();
+                    return new ValidateFetchArtifactConfigExecutor(request).execute();
                 case REQUEST_PUBLISH_ARTIFACT:
                     return new PublishArtifactExecutor(request, consoleLogger).execute();
                 case REQUEST_FETCH_ARTIFACT:

--- a/src/main/java/cd/go/artifact/docker/registry/executors/GetFetchArtifactMetadataExecutor.java
+++ b/src/main/java/cd/go/artifact/docker/registry/executors/GetFetchArtifactMetadataExecutor.java
@@ -16,15 +16,23 @@
 
 package cd.go.artifact.docker.registry.executors;
 
+import cd.go.artifact.docker.registry.annotation.ConfigMetadata;
+import cd.go.artifact.docker.registry.annotation.MetadataHelper;
+import cd.go.artifact.docker.registry.model.BuildFileArtifactPlanConfig;
+import cd.go.artifact.docker.registry.model.FetchArtifactConfig;
+import cd.go.artifact.docker.registry.model.ImageTagArtifactPlanConfig;
 import cd.go.artifact.docker.registry.utils.Util;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class GetFetchArtifactMetadataExecutor implements RequestExecutor {
     public GoPluginApiResponse execute() {
-        return DefaultGoPluginApiResponse.success(Util.GSON.toJson(new ArrayList<>()));
+
+        final List<ConfigMetadata> metadata = MetadataHelper.getMetadata(FetchArtifactConfig.class);
+        return DefaultGoPluginApiResponse.success(Util.GSON.toJson(metadata));
     }
 }
 

--- a/src/main/java/cd/go/artifact/docker/registry/executors/ValidateFetchArtifactConfigExecutor.java
+++ b/src/main/java/cd/go/artifact/docker/registry/executors/ValidateFetchArtifactConfigExecutor.java
@@ -17,14 +17,21 @@
 package cd.go.artifact.docker.registry.executors;
 
 import cd.go.artifact.docker.registry.annotation.ValidationResult;
+import cd.go.artifact.docker.registry.model.FetchArtifactConfig;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 
 public class ValidateFetchArtifactConfigExecutor implements RequestExecutor {
 
+    private final FetchArtifactConfig fetchArtifactConfig;
+
+    public ValidateFetchArtifactConfigExecutor(GoPluginApiRequest request) {
+        this.fetchArtifactConfig = FetchArtifactConfig.fromJSON(request.requestBody());
+    }
+
     @Override
     public GoPluginApiResponse execute() {
-        final ValidationResult validationResult = new ValidationResult();
-        return DefaultGoPluginApiResponse.success(validationResult.toJSON());
+        return DefaultGoPluginApiResponse.success(fetchArtifactConfig.validate().toJSON());
     }
 }

--- a/src/main/java/cd/go/artifact/docker/registry/model/FetchArtifactConfig.java
+++ b/src/main/java/cd/go/artifact/docker/registry/model/FetchArtifactConfig.java
@@ -18,9 +18,12 @@ package cd.go.artifact.docker.registry.model;
 
 import cd.go.artifact.docker.registry.annotation.FieldMetadata;
 import cd.go.artifact.docker.registry.annotation.Validatable;
+import cd.go.artifact.docker.registry.annotation.ValidationError;
+import cd.go.artifact.docker.registry.annotation.ValidationResult;
 import cd.go.artifact.docker.registry.utils.Util;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang.StringUtils;
 
 public class FetchArtifactConfig implements Validatable {
     @Expose
@@ -41,5 +44,14 @@ public class FetchArtifactConfig implements Validatable {
 
     public String getEnvironmentVariablePrefix() {
         return environmentVariablePrefix;
+    }
+
+    @Override
+    public ValidationResult validate() {
+        ValidationResult validationResult = new ValidationResult();
+        if (StringUtils.isNotBlank(environmentVariablePrefix) && !environmentVariablePrefix.matches("(?i)[a-z][a-z0-9_]*")) {
+            validationResult.addError(new ValidationError("EnvironmentVariablePrefix", "Invalid environment name prefix. Valid prefixes contain characters, numbers, and underscore; and can't start with a number."));
+        }
+        return validationResult;
     }
 }

--- a/src/main/java/cd/go/artifact/docker/registry/model/FetchArtifactConfig.java
+++ b/src/main/java/cd/go/artifact/docker/registry/model/FetchArtifactConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.artifact.docker.registry.model;
+
+import cd.go.artifact.docker.registry.annotation.FieldMetadata;
+import cd.go.artifact.docker.registry.annotation.Validatable;
+import cd.go.artifact.docker.registry.utils.Util;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class FetchArtifactConfig implements Validatable {
+    @Expose
+    @SerializedName("EnvironmentVariablePrefix")
+    @FieldMetadata(key = "EnvironmentVariablePrefix", required = false)
+    private String environmentVariablePrefix;
+
+    public FetchArtifactConfig() {
+    }
+
+    public FetchArtifactConfig(String environmentVariablePrefix) {
+        this.environmentVariablePrefix = environmentVariablePrefix;
+    }
+
+    public static FetchArtifactConfig fromJSON(String json) {
+        return Util.GSON.fromJson(json, FetchArtifactConfig.class);
+    }
+
+    public String getEnvironmentVariablePrefix() {
+        return environmentVariablePrefix;
+    }
+}

--- a/src/main/resources/fetch-artifact.template.html
+++ b/src/main/resources/fetch-artifact.template.html
@@ -1,1 +1,5 @@
-<div></div>
+<div class="form_item_block">
+    <label ng-class="{'is-invalid-label': GOINPUTNAME[EnvironmentVariablePrefix].$error.server}">Environment Variable Prefix:</label>
+    <input ng-class="{'is-invalid-input': GOINPUTNAME[EnvironmentVariablePrefix].$error.server}" type="text" ng-model="EnvironmentVariablePrefix" placeholder="PREFIX"/>
+    <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[EnvironmentVariablePrefix].$error.server}" ng-show="GOINPUTNAME[EnvironmentVariablePrefix].$error.server">{{GOINPUTNAME[EnvironmentVariablePrefix].$error.server}}</span>
+</div>

--- a/src/test/java/cd/go/artifact/docker/registry/ConsoleLoggerTest.java
+++ b/src/test/java/cd/go/artifact/docker/registry/ConsoleLoggerTest.java
@@ -50,7 +50,7 @@ public class ConsoleLoggerTest {
 
         final GoApiRequest request = argumentCaptor.getValue();
         assertThat(request.api()).isEqualTo(Constants.SEND_CONSOLE_LOG);
-        assertThat(request.apiVersion()).isEqualTo(Constants.API_VERSION);
+        assertThat(request.apiVersion()).isEqualTo(Constants.CONSOLE_LOG_PROCESSOR_API_VERSION);
 
         final String expectedJSON = "{\n" +
                 "  \"logLevel\": \"INFO\",\n" +
@@ -66,7 +66,7 @@ public class ConsoleLoggerTest {
 
         final GoApiRequest request = argumentCaptor.getValue();
         assertThat(request.api()).isEqualTo(Constants.SEND_CONSOLE_LOG);
-        assertThat(request.apiVersion()).isEqualTo(Constants.API_VERSION);
+        assertThat(request.apiVersion()).isEqualTo(Constants.CONSOLE_LOG_PROCESSOR_API_VERSION);
 
         final String expectedJSON = "{\n" +
                 "  \"logLevel\": \"ERROR\",\n" +

--- a/src/test/java/cd/go/artifact/docker/registry/executors/GetFetchArtifactMetadataExecutorTest.java
+++ b/src/test/java/cd/go/artifact/docker/registry/executors/GetFetchArtifactMetadataExecutorTest.java
@@ -27,8 +27,7 @@ public class GetFetchArtifactMetadataExecutorTest {
     @Test
     public void shouldReturnFetchArtifactMetadata() throws JSONException {
         final GoPluginApiResponse response = new GetFetchArtifactMetadataExecutor().execute();
-
-        final String expectedJSON = "[]";
+        final String expectedJSON = "[{\"key\":\"EnvironmentVariablePrefix\",\"metadata\":{\"required\":false,\"secure\":false}}]";
 
         assertThat(response.responseCode()).isEqualTo(200);
         JSONAssert.assertEquals(expectedJSON, response.responseBody(), true);

--- a/src/test/java/cd/go/artifact/docker/registry/executors/ValidateFetchArtifactConfigExecutorTest.java
+++ b/src/test/java/cd/go/artifact/docker/registry/executors/ValidateFetchArtifactConfigExecutorTest.java
@@ -16,18 +16,71 @@
 
 package cd.go.artifact.docker.registry.executors;
 
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import org.json.JSONObject;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
-public class ValidateFetchArtifactConfigExecutorTest {
-    @Test
-    public void shouldValidateMandatoryKeys() throws Exception {
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-        final GoPluginApiResponse response = new ValidateFetchArtifactConfigExecutor().execute();
+public class ValidateFetchArtifactConfigExecutorTest {
+
+    @Mock
+    private GoPluginApiRequest request;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void shouldEmptyEnvironmentVariablePrefixShouldBeValid() throws Exception {
+        String requestBody = new JSONObject().put("EnvironmentVariablePrefix", "").toString();
+        when(request.requestBody()).thenReturn(requestBody);
+
+        final GoPluginApiResponse response = new ValidateFetchArtifactConfigExecutor(request).execute();
 
         String expectedJSON = "[]";
         JSONAssert.assertEquals(expectedJSON, response.responseBody(), JSONCompareMode.NON_EXTENSIBLE);
     }
+
+    @Test
+    public void shouldValidateValidEnvironmentVariablePrefix() throws Exception {
+        String requestBody = new JSONObject().put("EnvironmentVariablePrefix", "ENVIRONMENT_VARIABLE").toString();
+        when(request.requestBody()).thenReturn(requestBody);
+
+        final GoPluginApiResponse response = new ValidateFetchArtifactConfigExecutor(request).execute();
+
+        String expectedJSON = "[]";
+        JSONAssert.assertEquals(expectedJSON, response.responseBody(), JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void shouldValidateInValidEnvironmentVariablePrefix() throws Exception {
+        String requestBody = new JSONObject().put("EnvironmentVariablePrefix", "1ENVIRONMENT_VARIABLE").toString();
+        when(request.requestBody()).thenReturn(requestBody);
+
+        final GoPluginApiResponse response = new ValidateFetchArtifactConfigExecutor(request).execute();
+
+        String expectedJSON = "[{\"key\":\"EnvironmentVariablePrefix\",\"message\":\"Invalid environment name prefix. Valid prefixes contain characters, numbers, and underscore; and can\\u0027t start with a number.\"}]";
+        JSONAssert.assertEquals(expectedJSON, response.responseBody(), JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void shouldValidateInValidEnvironmentVariablePrefixes() throws Exception {
+        String requestBody = new JSONObject().put("EnvironmentVariablePrefix", "ENVIRONMENT VARIABLE").toString();
+        when(request.requestBody()).thenReturn(requestBody);
+
+        final GoPluginApiResponse response = new ValidateFetchArtifactConfigExecutor(request).execute();
+
+        String expectedJSON = "[{\"key\":\"EnvironmentVariablePrefix\",\"message\":\"Invalid environment name prefix. Valid prefixes contain characters, numbers, and underscore; and can\\u0027t start with a number.\"}]";
+        JSONAssert.assertEquals(expectedJSON, response.responseBody(), JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+
 }


### PR DESCRIPTION
Sets an environment variable with the artifact image details in the plugin API response. Also adds a view element to the plugin config view to provide a prefix for the name of the environment variable being set, which is not required.

For more information, see the GoCD PR which this is based on: https://github.com/gocd/gocd/pull/5188#issue-216926760