### PR TITLE
Make plugin support old extension version too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Intellij files
 .idea/
 

--- a/src/main/java/cd/go/artifact/docker/registry/Constants.java
+++ b/src/main/java/cd/go/artifact/docker/registry/Constants.java
@@ -20,16 +20,19 @@ import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
 
 import java.util.Collections;
 
+import static java.util.Arrays.asList;
+
 public interface Constants {
     // The type of this extension
     String EXTENSION_TYPE = "artifact";
 
     // The extension point API version that this plugin understands
+    String OLDER_EXTENSION_API_VERSION = "1.0";
     String EXTENSION_API_VERSION = "2.0";
     String CONSOLE_LOG_PROCESSOR_API_VERSION = "1.0";
 
     // the identifier of this plugin
-    GoPluginIdentifier PLUGIN_IDENTIFIER = new GoPluginIdentifier(EXTENSION_TYPE, Collections.singletonList(EXTENSION_API_VERSION));
+    GoPluginIdentifier PLUGIN_IDENTIFIER = new GoPluginIdentifier(EXTENSION_TYPE, asList(OLDER_EXTENSION_API_VERSION, EXTENSION_API_VERSION));
 
     // requests that the plugin makes to the server
     String REQUEST_SERVER_PREFIX = "go.processor";


### PR DESCRIPTION
In this case, version 2 just adds some functionality. So, if the plugin claims that it supports version 1 too, it will be valid.

For #28 